### PR TITLE
Add support for specifying a custom CA bundle

### DIFF
--- a/blazar/config.py
+++ b/blazar/config.py
@@ -65,7 +65,9 @@ os_opts = [
                help='A domain name the os_admin_username belongs to.'),
     cfg.StrOpt('os_admin_project_domain_name',
                default='Default',
-               help='A domain name the os_admin_project_name belongs to')
+               help='A domain name the os_admin_project_name belongs to'),
+    cfg.StrOpt('cafile',
+               help='Path of the custom CA certificates bundle.'),
 ]
 
 api_opts = [

--- a/blazar/utils/openstack/base.py
+++ b/blazar/utils/openstack/base.py
@@ -85,7 +85,15 @@ def client_kwargs(**_kwargs):
         auth_kwargs.update(project_name=project_name)
 
     auth = v3.Password(**auth_kwargs)
-    sess = session.Session(auth=auth)
+
+    sess_kwargs = dict(
+        auth=auth
+    )
+
+    if CONF.cafile:
+        sess_kwargs.update(verify=CONF.cafile)
+
+    sess = session.Session(**sess_kwargs)
 
     kwargs.setdefault('session', sess)
     kwargs.setdefault('region_name', region_name)
@@ -117,7 +125,15 @@ def client_user_kwargs(**_kwargs):
     data = admin_ks_client.tokens.get_token_data(ctx.auth_token)
     access_info = create_access_info(body=data, auth_token=ctx.auth_token)
     auth = access.AccessInfoPlugin(access_info, auth_url=auth_url)
-    sess = session.Session(auth=auth)
+
+    sess_kwargs = dict(
+        auth=auth
+    )
+
+    if CONF.cafile:
+        sess_kwargs.update(verify=CONF.cafile)
+
+    sess = session.Session(**sess_kwargs)
 
     kwargs.setdefault('session', sess)
     kwargs.setdefault('region_name', region_name)

--- a/blazar/utils/openstack/neutron.py
+++ b/blazar/utils/openstack/neutron.py
@@ -81,7 +81,12 @@ class BlazarNeutronClient(object):
                            project_name=project_name,
                            user_domain_name=user_domain_name,
                            project_domain_name=project_domain_name)
-        sess = session.Session(auth=auth)
+        sess_kwargs = dict(
+            auth=auth
+        )
+        if CONF.cafile:
+            sess_kwargs.update(verify=CONF.cafile)
+        sess = session.Session(**sess_kwargs)
         kwargs.setdefault('session', sess)
         kwargs.setdefault('region_name', region_name)
         kwargs.setdefault('endpoint_type', CONF.neutron.endpoint_type + 'URL')

--- a/blazar/utils/openstack/nova.py
+++ b/blazar/utils/openstack/nova.py
@@ -153,10 +153,18 @@ class BlazarNovaClient(object):
             if "v2.0" not in auth_url:
                 kwargs.setdefault('project_domain_name', project_domain_name)
                 kwargs.setdefault('user_domain_name', user_domain_name)
+
+            if CONF.cafile:
+                kwargs.setdefault('cacert', CONF.cafile)
         else:
             auth = token_endpoint.Token(endpoint_override,
                                         auth_token)
-            sess = session.Session(auth=auth)
+            sess_kwargs = dict(
+                auth=auth
+            )
+            if CONF.cafile:
+                sess_kwargs.update(verify=CONF.cafile)
+            sess = session.Session(**sess_kwargs)
             kwargs.setdefault('session', sess)
 
         kwargs.setdefault('endpoint_type', CONF.nova.endpoint_type + 'URL')

--- a/blazar/utils/openstack/placement.py
+++ b/blazar/utils/openstack/placement.py
@@ -83,7 +83,12 @@ class BlazarPlacementClient(object):
                            project_name=project_name,
                            user_domain_name=user_domain_name,
                            project_domain_name=project_domain_name)
-        sess = session.Session(auth=auth)
+        sess_kwargs = dict(
+            auth=auth
+        )
+        if CONF.cafile:
+            sess_kwargs.update(verify=CONF.cafile)
+        sess = session.Session(**sess_kwargs)
         # Set accept header on every request to ensure we notify placement
         # service of our response body media type preferences.
         headers = {'accept': 'application/json'}

--- a/releasenotes/notes/support-passing-custom-ca-bundle-df71047568cd82f6.yaml
+++ b/releasenotes/notes/support-passing-custom-ca-bundle-df71047568cd82f6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The Blazar service now supports using a custom CA certificate bundle with
+    the ``[DEFAULT]/cafile`` option. This allows for deployment on OpenStack
+    clouds that are using HTTPS endpoints with certificates signed by a custom
+    CA. `LP#2045281 <https://launchpad.net/bugs/2045281>`__


### PR DESCRIPTION
Adds the new config option ``cafile``, which is passed into the Session invocations for SSL verification.

Partial-Bug: #2045281

Change-Id: I2ec5bc7ac929534175d380d2e3e535a5e7abd962 (cherry picked from commit 0481ad4ad9d72b9d65d42ef2d489b653c9f76bed)