### PR TITLE
Add C901 to ignore list of pep8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,10 @@ exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,tools,api-ref
 # W503 line break before binary operator
 # W504 line break after binary operator
 # E402 module level import not at top of file
-ignore=H105,H238,E123,E402,W503,W504
+# NOTE(seunghun1ee): Remove C901 when ManagerService.create_lease()
+# in /blazar/manager/service.py get refactored
+# C901 Function is too complex
+ignore=H105,H238,E123,E402,W503,W504,C901
 # [H904] Delay string interpolations at logging calls.
 enable-extensions=H904
 # To get a list of functions that have a complexity of 17 or more, set


### PR DESCRIPTION
C901 Function is too complex is catching ManagerService.create_lease() because the function has more than 5 potential branches.

Because the function is in WIP in master branch, ignore C901 at least until the function is in stable state.